### PR TITLE
Fix cooldown time usage

### DIFF
--- a/src/main/java/com/gtnh/findit/service/cooldown/SearchCooldownService.java
+++ b/src/main/java/com/gtnh/findit/service/cooldown/SearchCooldownService.java
@@ -13,7 +13,7 @@ public class SearchCooldownService {
      * @return true if player has active cooldown
      */
     public boolean checkSearchCooldown(EntityPlayerMP player) {
-        long time = player.getEntityWorld().getTotalWorldTime();
+        long time = player.getServerForPlayer().func_73046_m().getTickCounter();
         Long lastTime = lastSearchTime.get(player);
 
         if (lastTime != null && time - lastTime < FindItConfig.SEARCH_COOLDOWN) {


### PR DESCRIPTION
Total world time is different for each dimension. EntityPlayerMP object stays the same on dimension change. This leads to bug when transition from older dimension to newer causes the cooldown to increase greatly.