### PR TITLE
findit/util/AbstractStackFinder: Add check for whether NEI Search is focused

### DIFF
--- a/src/main/java/com/gtnh/findit/service/blockfinder/ClientBlockFindService.java
+++ b/src/main/java/com/gtnh/findit/service/blockfinder/ClientBlockFindService.java
@@ -16,7 +16,7 @@ import org.lwjgl.input.Keyboard;
 public class ClientBlockFindService extends BlockFindService {
 
     public ClientBlockFindService() {
-        API.addHashBind("gui.findit.find_block", Keyboard.KEY_Y + NEIClientUtils.SHIFT_HASH);
+        API.addHashBind("gui.findit.find_block", Keyboard.KEY_Y);
         GuiContainerManager.addInputHandler(new BlockFindInputHandler());
     }
 

--- a/src/main/java/com/gtnh/findit/service/itemfinder/ClientItemFindService.java
+++ b/src/main/java/com/gtnh/findit/service/itemfinder/ClientItemFindService.java
@@ -33,7 +33,7 @@ public class ClientItemFindService extends ItemFindService {
 
     public ClientItemFindService() {
         if (!FindIt.isExtraUtilitiesLoaded()) {
-            API.addHashBind("gui.findit.find_item", Keyboard.KEY_T + NEIClientUtils.SHIFT_HASH);
+            API.addHashBind("gui.findit.find_item", Keyboard.KEY_T);
         }
         GuiContainerManager.addInputHandler(new ItemFindInputHandler());
 

--- a/src/main/java/com/gtnh/findit/util/AbstractStackFinder.java
+++ b/src/main/java/com/gtnh/findit/util/AbstractStackFinder.java
@@ -21,7 +21,9 @@ public abstract class AbstractStackFinder implements IContainerInputHandler {
         }
 
         LayoutManager layout = LayoutManager.instance();
-        if (layout == null || LayoutManager.itemPanel == null || NEIClientConfig.isHidden()) {
+        if (layout == null || LayoutManager.itemPanel == null || NEIClientConfig.isHidden()
+                || LayoutManager.searchField == null || LayoutManager.searchField.focused()
+        ) {
             return false;
         }
 

--- a/src/main/java/com/gtnh/findit/util/AbstractStackFinder.java
+++ b/src/main/java/com/gtnh/findit/util/AbstractStackFinder.java
@@ -1,5 +1,6 @@
 package com.gtnh.findit.util;
 
+import appeng.client.gui.implementations.*;
 import codechicken.nei.LayoutManager;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.guihook.GuiContainerManager;
@@ -16,6 +17,16 @@ public abstract class AbstractStackFinder implements IContainerInputHandler {
     @Override
     public boolean keyTyped(GuiContainer window, char c, int key) {
         
+        return false;
+    }
+
+    @Override
+    public void onKeyTyped(GuiContainer guiContainer, char c, int i) {
+
+    }
+
+    @Override
+    public boolean lastKeyTyped(GuiContainer guiContainer, char c, int i) {
         if (!NEIClientConfig.isKeyHashDown(getKeyBindId())) {
             return false;
         }
@@ -27,21 +38,11 @@ public abstract class AbstractStackFinder implements IContainerInputHandler {
             return false;
         }
 
-        ItemStack stack = GuiContainerManager.getStackMouseOver(window);
+        ItemStack stack = GuiContainerManager.getStackMouseOver(guiContainer);
         if (stack == null || stack.getItem() == null) {
             return false;
         }
         return findStack(stack);
-    }
-
-    @Override
-    public void onKeyTyped(GuiContainer guiContainer, char c, int i) {
-
-    }
-
-    @Override
-    public boolean lastKeyTyped(GuiContainer guiContainer, char c, int i) {
-        return false;
     }
 
     @Override

--- a/src/main/java/com/gtnh/findit/util/AbstractStackFinder.java
+++ b/src/main/java/com/gtnh/findit/util/AbstractStackFinder.java
@@ -16,7 +16,6 @@ public abstract class AbstractStackFinder implements IContainerInputHandler {
 
     @Override
     public boolean keyTyped(GuiContainer window, char c, int key) {
-        
         return false;
     }
 
@@ -32,9 +31,7 @@ public abstract class AbstractStackFinder implements IContainerInputHandler {
         }
 
         LayoutManager layout = LayoutManager.instance();
-        if (layout == null || LayoutManager.itemPanel == null || NEIClientConfig.isHidden()
-                || LayoutManager.searchField == null || LayoutManager.searchField.focused()
-        ) {
+        if (layout == null || LayoutManager.itemPanel == null || NEIClientConfig.isHidden()) {
             return false;
         }
 


### PR DESCRIPTION
This should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10297.

~There's a related bug, making sure no TextField is focused when using FindIt. I believe it'll require adding a new interface that allows us to check whether any TextField widget in a GUI is focused.~

This fixes that too.