### PR TITLE
Fix inventory slots not being highlighted

### DIFF
--- a/src/main/java/com/gtnh/findit/FindIt.java
+++ b/src/main/java/com/gtnh/findit/FindIt.java
@@ -1,6 +1,5 @@
 package com.gtnh.findit;
 
-import codechicken.nei.guihook.GuiContainerManager;
 import com.gtnh.findit.service.blockfinder.BlockFindService;
 import com.gtnh.findit.service.blockfinder.ClientBlockFindService;
 import com.gtnh.findit.service.cooldown.SearchCooldownService;
@@ -48,11 +47,6 @@ public class FindIt {
 
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
-        if (event.getSide() == Side.CLIENT && FindIt.isExtraUtilitiesLoaded()) {
-            GuiContainerManager.inputHandlers.removeIf((inputHandler) ->
-                    inputHandler.getClass().getName().equals("com.rwtema.extrautils.nei.ping.NEIPing")
-            );
-        }
     }
 
     public static SearchCooldownService getCooldownService() {

--- a/src/main/java/com/gtnh/findit/service/itemfinder/ClientItemFindService.java
+++ b/src/main/java/com/gtnh/findit/service/itemfinder/ClientItemFindService.java
@@ -1,7 +1,7 @@
 package com.gtnh.findit.service.itemfinder;
 
-import codechicken.nei.NEIClientUtils;
 import codechicken.nei.api.API;
+import codechicken.nei.event.NEIConfigsLoadedEvent;
 import codechicken.nei.guihook.GuiContainerManager;
 import com.gtnh.findit.FindIt;
 import com.gtnh.findit.FindItNetwork;
@@ -38,6 +38,7 @@ public class ClientItemFindService extends ItemFindService {
         GuiContainerManager.addInputHandler(new ItemFindInputHandler());
 
         MinecraftForge.EVENT_BUS.register(new GuiListener());
+        MinecraftForge.EVENT_BUS.register(new NEIEventListener());
         FMLCommonHandler.instance().bus().register(new TickListener());
     }
 
@@ -137,6 +138,17 @@ public class ClientItemFindService extends ItemFindService {
                 if (stack != null && stack.getItem() == targetItem && stack.getItemDamage() == targetMeta) {
                     highlightedSlots.add(slotId);
                 }
+            }
+        }
+    }
+
+    public static class NEIEventListener {
+        @SubscribeEvent
+        public void onNEIConfigsLoaded(NEIConfigsLoadedEvent event) {
+            if (FindIt.isExtraUtilitiesLoaded()) {
+                GuiContainerManager.inputHandlers.removeIf((inputHandler) ->
+                        inputHandler.getClass().getName().equals("com.rwtema.extrautils.nei.ping.NEIPing")
+                );
             }
         }
     }


### PR DESCRIPTION
`NEIPing` is registered within `IConfigureNEI`, so it was actually not removed. It was not problem before because both mods use `keyTyped` and FindIt registers earlier, resulting in FindIt handler being called earlier. In https://github.com/GTNewHorizons/FindIt/pull/8 it's moved to `lastKeyTyped`, so XU handler was called earlier.