### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,21 +1,17 @@
 {
-	"modListVersion": 2,
-	"modList": [{
-		"modid": "${modId}",
-		"name": "${modName}",
-		"description": "Now where did I put that EV mixer...",
-		"version": "${modVersion}",
-		"mcversion": "${minecraftVersion}",
-		"url": "https://github.com/GTNewHorizons/FindIt",
-		"updateUrl": "",
-		"authorList": ["mitchej123"],
-		"credits": "Heavily inspired from Buuz135/findme",
-		"logoFile": "",
-		"screenshots": [],
-		"parent": "",
-		"requiredMods": [],
-		"dependencies": ["NotEnoughItems"],
-		"dependants": [],
-		"useDependencyInformation": true
-	}]
+  "modListVersion": 2,
+  "modList": [{
+    "modid": "${modId}",
+    "name": "${modName}",
+    "description": "Now where did I put that EV mixer...",
+    "version": "${modVersion}",
+    "mcversion": "${minecraftVersion}",
+    "url": "https://github.com/GTNewHorizons/FindIt",
+    "updateUrl": "",
+    "authorList": ["mitchej123"],
+    "credits": "Heavily inspired from Buuz135/findme",
+    "logoFile": "",
+    "screenshots": [],
+    "parent": ""
+  }]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.