### PR TITLE
feat: add support for Forestry backpacks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,4 +5,5 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.05:dev')
     compileOnly('com.github.GTNewHorizons:EnderIO:2.8.17:dev')
     compileOnly('com.github.GTNewHorizons:Draconic-Evolution:1.3.6-GTNH:dev')
+    api('com.github.GTNewHorizons:ForestryMC:4.9.16:dev')
 }

--- a/src/main/java/com/gtnh/findit/FindIt.java
+++ b/src/main/java/com/gtnh/findit/FindIt.java
@@ -28,11 +28,11 @@ public class FindIt {
     @Mod.Instance(MOD_ID)
     public static FindIt INSTANCE;
 
-    private boolean extraUtilitiesLoaded;
-    private boolean gregTechloaded;
-    private boolean enderIOloaded;
-
-    private boolean draconicEvolutionLoaded;
+    private boolean isDraconicEvolutionLoaded;
+    private boolean isEnderIOLoaded;
+    private boolean isExtraUtilitiesLoaded;
+    private boolean isForestryLoaded;
+    private boolean isGregTechLoaded;
 
     private SearchCooldownService cooldownService;
     private BlockFindService blockFindService;
@@ -40,10 +40,11 @@ public class FindIt {
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-        this.extraUtilitiesLoaded = Loader.isModLoaded("ExtraUtilities");
-        this.gregTechloaded = Loader.isModLoaded("gregtech");
-        this.enderIOloaded = Loader.isModLoaded("EnderIO");
-        this.draconicEvolutionLoaded = Loader.isModLoaded("DraconicEvolution");
+        this.isExtraUtilitiesLoaded = Loader.isModLoaded("ExtraUtilities");
+        this.isGregTechLoaded = Loader.isModLoaded("gregtech");
+        this.isEnderIOLoaded = Loader.isModLoaded("EnderIO");
+        this.isDraconicEvolutionLoaded = Loader.isModLoaded("DraconicEvolution");
+        this.isForestryLoaded = Loader.isModLoaded("Forestry");
 
         FindItConfig.setup(event.getSuggestedConfigurationFile());
         boolean isClient = event.getSide() == Side.CLIENT;
@@ -66,18 +67,22 @@ public class FindIt {
     }
 
     public static boolean isExtraUtilitiesLoaded() {
-        return INSTANCE.extraUtilitiesLoaded;
+        return INSTANCE.isExtraUtilitiesLoaded;
     }
 
     public static boolean isGregTechLoaded() {
-        return INSTANCE.gregTechloaded;
+        return INSTANCE.isGregTechLoaded;
     }
 
     public static boolean isEnderIOLoaded() {
-        return INSTANCE.enderIOloaded;
+        return INSTANCE.isEnderIOLoaded;
     }
 
     public static boolean isDraconicEvolutionLoaded() {
-        return INSTANCE.draconicEvolutionLoaded;
+        return INSTANCE.isDraconicEvolutionLoaded;
+    }
+
+    public static boolean isForestryLoaded() {
+        return INSTANCE.isForestryLoaded;
     }
 }

--- a/src/main/java/com/gtnh/findit/util/mods/ForestryUtils.java
+++ b/src/main/java/com/gtnh/findit/util/mods/ForestryUtils.java
@@ -1,0 +1,37 @@
+package com.gtnh.findit.util.mods;
+
+import java.util.Optional;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import forestry.storage.inventory.ItemInventoryBackpack;
+import forestry.storage.items.ItemBackpack;
+
+public class ForestryUtils {
+
+    private ForestryUtils() {}
+
+    public static Optional<IInventory> getInventoryOfPotentialStorageItem(ItemStack potentialBackpackItemStack) {
+        // Checks for Forestry backpacks.
+        Item item = potentialBackpackItemStack.getItem();
+        if (item instanceof ItemBackpack) {
+            ItemBackpack backpack = (ItemBackpack) item;
+
+            // We're running the GUI code client-side only, thus the only player interacting with the GUI is the
+            // player that the backpack's inventory is checked against.
+            EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+
+            ItemInventoryBackpack inventory = new ItemInventoryBackpack(
+                    player,
+                    backpack.getBackpackSize(),
+                    potentialBackpackItemStack);
+            return Optional.of(inventory);
+        }
+
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
If the item stack one is looking for is inside a forestry backpack, said backpack will be highlighted as well, indicating that the item is contained within. Mostly useful for when your mining backpack picks items up while crafting without you noticing and wondering where they went...

It might make sense to add a config flag for this with a default value of `true`. Maybe some people might want to disable this behavior.

Backpack contains cobblestone:
![2024-09-25_10 21 35](https://github.com/user-attachments/assets/10e08c8a-fdbf-428c-a924-59711a8fbfaf)

Searching for cobblestone:
![2024-09-25_10 21 42](https://github.com/user-attachments/assets/ed834f41-bad4-4b83-97b2-64467a33d1f6)
