### PR TITLE
feat: add configurable highlight color

### DIFF
--- a/src/main/java/com/gtnh/findit/FindItConfig.java
+++ b/src/main/java/com/gtnh/findit/FindItConfig.java
@@ -16,6 +16,7 @@ public class FindItConfig {
     public static boolean SEARCH_IN_ENDERIO_CONDUITS = false;
     public static int ITEM_HIGHLIGHTING_DURATION = 10;
     public static int BLOCK_HIGHLIGHTING_DURATION = 8;
+    public static int ITEM_HIGHLIGHTING_COLOR = 0xFFFF8726;
 
     public static void setup(final File file) {
         final Configuration config = new Configuration(file);
@@ -73,6 +74,14 @@ public class FindItConfig {
                     "EnableRotateView",
                     "false",
                     "Rotate player's view when searched").getBoolean();
+
+            ITEM_HIGHLIGHTING_COLOR = Integer.parseUnsignedInt(
+                    config.get(
+                            Configuration.CATEGORY_GENERAL,
+                            "ItemHighlightingColor",
+                            "FFFF8726",
+                            "Item highlighting color as a hexadecimal color code. For example 0xFFFF8726").getString(),
+                    16);
         } catch (Exception ignore) {} finally {
             if (config.hasChanged()) config.save();
         }

--- a/src/main/java/com/gtnh/findit/service/itemfinder/ClientItemFindService.java
+++ b/src/main/java/com/gtnh/findit/service/itemfinder/ClientItemFindService.java
@@ -126,7 +126,7 @@ public class ClientItemFindService extends ItemFindService {
                 }
             }
 
-            slotHighlighter.highlightSlots(gui, highlightedSlots, 0xFFFF8726);
+            slotHighlighter.highlightSlots(gui, highlightedSlots, FindItConfig.ITEM_HIGHLIGHTING_COLOR);
         }
     }
 


### PR DESCRIPTION
This PR adds a configuration field that lets one configure the highlight color. The existing color has been used as default value.

The only thing I am not sure about is the name of the config field. `ItemHighlightColor` is grammatically correct (or at least more fitting). I used `highlighting`, since it was the same as the other config key names. Let me know what you prefer and I'll change it.