### PR TITLE
feat: add configuration option to disable empty item stack highlighting

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,4 +6,8 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:EnderIO:2.8.17:dev')
     compileOnly('com.github.GTNewHorizons:Draconic-Evolution:1.3.10-GTNH:dev')
     api('com.github.GTNewHorizons:ForestryMC:4.9.16:dev')
+
+    // For testing in dev environment.
+    devOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:1.13.5-GTNH')
+    devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.8.1")
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,6 +8,6 @@ dependencies {
     api('com.github.GTNewHorizons:ForestryMC:4.9.16:dev')
 
     // For testing in dev environment.
-    devOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:1.13.5-GTNH')
-    devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.8.1")
+    //runtimeOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:1.13.5-GTNH')
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.8.1")
 }

--- a/src/main/java/com/gtnh/findit/FindItConfig.java
+++ b/src/main/java/com/gtnh/findit/FindItConfig.java
@@ -17,7 +17,7 @@ public class FindItConfig {
     public static int ITEM_HIGHLIGHTING_DURATION = 10;
     public static int BLOCK_HIGHLIGHTING_DURATION = 8;
     public static int ITEM_HIGHLIGHTING_COLOR = 0xFFFF8726;
-    public static boolean ITEM_HIGHLIGHT_EMPTY_ITEMSTACKS = false;
+    public static boolean ITEM_HIGHLIGHTING_EMPTY_ITEMSTACKS = false;
 
     public static void setup(final File file) {
         final Configuration config = new Configuration(file);
@@ -84,9 +84,9 @@ public class FindItConfig {
                             "Item highlighting color as a hexadecimal color code. For example 0xFFFF8726").getString(),
                     16);
 
-            ITEM_HIGHLIGHT_EMPTY_ITEMSTACKS = config.get(
+            ITEM_HIGHLIGHTING_EMPTY_ITEMSTACKS = config.get(
                     Configuration.CATEGORY_GENERAL,
-                    "ItemHighlightEmptyItemStacks",
+                    "ItemHighlightingEmptyItemStacks",
                     "false",
                     "If true, the item stack size is ignored. If false, items are only highlighted if their stack size is greater than one.\n"
                             + "This is useful when working with barrels or storage drawers.")

--- a/src/main/java/com/gtnh/findit/FindItConfig.java
+++ b/src/main/java/com/gtnh/findit/FindItConfig.java
@@ -17,7 +17,7 @@ public class FindItConfig {
     public static int ITEM_HIGHLIGHTING_DURATION = 10;
     public static int BLOCK_HIGHLIGHTING_DURATION = 8;
     public static int ITEM_HIGHLIGHTING_COLOR = 0xFFFF8726;
-    public static boolean ITEM_HIGHLIGHTING_EMPTY_ITEMSTACKS = false;
+    public static boolean ITEM_HIGHLIGHTING_EMPTY_ITEMSTACKS = true;
 
     public static void setup(final File file) {
         final Configuration config = new Configuration(file);
@@ -87,7 +87,7 @@ public class FindItConfig {
             ITEM_HIGHLIGHTING_EMPTY_ITEMSTACKS = config.get(
                     Configuration.CATEGORY_GENERAL,
                     "ItemHighlightingEmptyItemStacks",
-                    "false",
+                    "true",
                     "If true, the item stack size is ignored. If false, items are only highlighted if their stack size is greater than zero.\n"
                             + "This is useful when working with barrels or storage drawers.")
                     .getBoolean();

--- a/src/main/java/com/gtnh/findit/FindItConfig.java
+++ b/src/main/java/com/gtnh/findit/FindItConfig.java
@@ -88,7 +88,7 @@ public class FindItConfig {
                     Configuration.CATEGORY_GENERAL,
                     "ItemHighlightingEmptyItemStacks",
                     "false",
-                    "If true, the item stack size is ignored. If false, items are only highlighted if their stack size is greater than one.\n"
+                    "If true, the item stack size is ignored. If false, items are only highlighted if their stack size is greater than zero.\n"
                             + "This is useful when working with barrels or storage drawers.")
                     .getBoolean();
         } catch (Exception ignore) {} finally {

--- a/src/main/java/com/gtnh/findit/FindItConfig.java
+++ b/src/main/java/com/gtnh/findit/FindItConfig.java
@@ -17,6 +17,7 @@ public class FindItConfig {
     public static int ITEM_HIGHLIGHTING_DURATION = 10;
     public static int BLOCK_HIGHLIGHTING_DURATION = 8;
     public static int ITEM_HIGHLIGHTING_COLOR = 0xFFFF8726;
+    public static boolean ITEM_HIGHLIGHT_EMPTY_ITEMSTACKS = false;
 
     public static void setup(final File file) {
         final Configuration config = new Configuration(file);
@@ -82,6 +83,14 @@ public class FindItConfig {
                             "FFFF8726",
                             "Item highlighting color as a hexadecimal color code. For example 0xFFFF8726").getString(),
                     16);
+
+            ITEM_HIGHLIGHT_EMPTY_ITEMSTACKS = config.get(
+                    Configuration.CATEGORY_GENERAL,
+                    "ItemHighlightEmptyItemStacks",
+                    "false",
+                    "If true, the item stack size is ignored. If false, items are only highlighted if their stack size is greater than one.\n"
+                            + "This is useful when working with barrels or storage drawers.")
+                    .getBoolean();
         } catch (Exception ignore) {} finally {
             if (config.hasChanged()) config.save();
         }

--- a/src/main/java/com/gtnh/findit/service/itemfinder/FindItemRequest.java
+++ b/src/main/java/com/gtnh/findit/service/itemfinder/FindItemRequest.java
@@ -96,7 +96,7 @@ public class FindItemRequest implements IMessage {
      */
     private boolean shouldHighlightItemStack(ItemStack itemStack) {
         // If the user requested to highlight empty item stacks, we early return to make sure that we do so.
-        if (FindItConfig.ITEM_HIGHLIGHT_EMPTY_ITEMSTACKS) {
+        if (FindItConfig.ITEM_HIGHLIGHTING_EMPTY_ITEMSTACKS) {
             return true;
         }
 

--- a/src/main/java/com/gtnh/findit/service/itemfinder/FindItemRequest.java
+++ b/src/main/java/com/gtnh/findit/service/itemfinder/FindItemRequest.java
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.gtnh.findit.FindIt;
+import com.gtnh.findit.FindItConfig;
 import com.gtnh.findit.service.blockfinder.BlockFoundResponse;
 import com.gtnh.findit.util.ProtoUtils;
 import com.gtnh.findit.util.mods.ForestryUtils;
@@ -82,7 +83,24 @@ public class FindItemRequest implements IMessage {
             }
         }
 
-        return StackInfo.equalItemAndNBT(targetStack, stack, true);
+        return StackInfo.equalItemAndNBT(targetStack, stack, true) && shouldHighlightItemStack(stack);
+    }
+
+    /**
+     * Returns whether an {@code ItemStack} should be highlighted inside inventories. The method explicitly checks for
+     * empty item stacks and consults the mod's configuration to determine whether empty item stacks should be
+     * highlighted or not.
+     *
+     * @param itemStack The {@code ItemStack} to check.
+     * @return {@code true} if the {@code ItemStack} should be highlighted, {@code false} otherwise.
+     */
+    private boolean shouldHighlightItemStack(ItemStack itemStack) {
+        // If the user requested to highlight empty item stacks, we early return to make sure that we do so.
+        if (FindItConfig.ITEM_HIGHLIGHT_EMPTY_ITEMSTACKS) {
+            return true;
+        }
+
+        return itemStack.stackSize > 0;
     }
 
     public static class Handler implements IMessageHandler<FindItemRequest, BlockFoundResponse> {


### PR DESCRIPTION
This is another QoL update. I noticed that the item highlight feature also highlights items inside of storage drawers if their stack size is 0. This usually happens if you lock the items using the key and remove all of them.

The PR adds a new configuration option that can be set to true to restore the old behavior. The new behavior does not highlight inventories that contain item stacks of size zero.

The behavior before the change. The inventory was highlighted and its stack size is zero:
![2024-09-26_23 42 07](https://github.com/user-attachments/assets/397b4f34-c139-4a56-8ab0-cba07effacdd)

Having the config key set to false blocks the application of the highlight:
![2024-09-26_23 17 29](https://github.com/user-attachments/assets/14e14177-1cdb-45cf-8006-e8dacd136ec0)
