### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/com/gtnh/findit/handler/MinecraftProvider.java
+++ b/src/main/java/com/gtnh/findit/handler/MinecraftProvider.java
@@ -35,12 +35,12 @@ public class MinecraftProvider implements IStackFilterProvider {
         if (tileEntity instanceof IFluidHandler handler) {
             FluidTankInfo[] tankInfo = handler.getTankInfo(ForgeDirection.UNKNOWN);
             FluidStackFilter filter = new FluidStackFilter();
-
-            for (FluidTankInfo info : tankInfo) {
-                filter.add(info.fluid);
+            if (tankInfo != null) {
+                for (FluidTankInfo info : tankInfo) {
+                    filter.add(info.fluid);
+                }
             }
-
-            anyFilter.add(filter);
+            if (!filter.isEmpty()) anyFilter.add(filter);
         }
 
         return anyFilter.isEmpty() ? null : anyFilter;


### PR DESCRIPTION
```
java.lang.NullPointerException
at com.gtnh.findit.handler.MinecraftProvider.getFilter(MinecraftProvider.java:39)
at com.gtnh.findit.service.itemfinder.FindItemRequest.isTileSatisfies(FindItemRequest.java:93)
at com.gtnh.findit.service.itemfinder.ItemFindService.handleRequest(ItemFindService.java:34)
at com.gtnh.findit.service.itemfinder.FindItemRequest$Handler.onMessage(FindItemRequest.java:107)
at com.gtnh.findit.service.itemfinder.FindItemRequest$Handler.onMessage(FindItemRequest.java:102)
at cpw.mods.fml.common.network.simpleimpl.SimpleChannelHandlerWrapper.channelRead0(SimpleChannelHandlerWrapper.java:37)
at cpw.mods.fml.common.network.simpleimpl.SimpleChannelHandlerWrapper.channelRead0(SimpleChannelHandlerWrapper.java:17)
at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:98)
at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337)
at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323)
at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:111)
at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337)
at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323)
at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785)
at io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:169)
at cpw.mods.fml.common.network.internal.FMLProxyPacket.func_148833_a(FMLProxyPacket.java:77)
at net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212)
at net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:165)
at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:659)
at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:111)
at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```