### PR TITLE
feat: add thaumcraft integration to search for essentia

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,9 +10,14 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:AdventureBackpack2:1.2.2-GTNH:dev')
     compileOnly("com.github.GTNewHorizons:ProjectRed:4.10.5-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.4.3-GTNH:dev")
+    compileOnly("curse.maven:thaumcraft-nei-plugin-225095:2241913")
+    compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
 
     // For testing in dev environment.
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:1.13.5-GTNH')
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.8.1")
+    // runtimeOnlyNonPublishable('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Baubles:1.0.4:dev")
+    // runtimeOnlyNonPublishable('curse.maven:thaumcraft-nei-plugin-225095:2241913')
 
 }

--- a/src/main/java/com/gtnh/findit/FindIt.java
+++ b/src/main/java/com/gtnh/findit/FindIt.java
@@ -4,12 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.gtnh.findit.IStackFilter.IStackFilterProvider;
-import com.gtnh.findit.handler.AdventureBackpackProvider;
-import com.gtnh.findit.handler.BackpackProvider;
-import com.gtnh.findit.handler.DraconicEvolutionProvider;
-import com.gtnh.findit.handler.ForestryStackFilterProvider;
-import com.gtnh.findit.handler.MinecraftProvider;
-import com.gtnh.findit.handler.ProjectRedExplorationProvider;
+import com.gtnh.findit.handler.*;
 import com.gtnh.findit.service.blockfinder.BlockFindService;
 import com.gtnh.findit.service.blockfinder.ClientBlockFindService;
 import com.gtnh.findit.service.cooldown.SearchCooldownService;
@@ -83,6 +78,10 @@ public class FindIt {
 
         if (Loader.isModLoaded("Backpack")) {
             this.pluginsList.add(new BackpackProvider());
+        }
+
+        if (Loader.isModLoaded("thaumcraftneiplugin") && Loader.isModLoaded("Thaumcraft")) {
+            this.pluginsList.add(new ThaumcraftProvider());
         }
 
         this.pluginsList.add(new MinecraftProvider());

--- a/src/main/java/com/gtnh/findit/FindIt.java
+++ b/src/main/java/com/gtnh/findit/FindIt.java
@@ -4,7 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.gtnh.findit.IStackFilter.IStackFilterProvider;
-import com.gtnh.findit.handler.*;
+import com.gtnh.findit.handler.AdventureBackpackProvider;
+import com.gtnh.findit.handler.BackpackProvider;
+import com.gtnh.findit.handler.DraconicEvolutionProvider;
+import com.gtnh.findit.handler.ForestryStackFilterProvider;
+import com.gtnh.findit.handler.MinecraftProvider;
+import com.gtnh.findit.handler.ProjectRedExplorationProvider;
+import com.gtnh.findit.handler.ThaumcraftProvider;
 import com.gtnh.findit.service.blockfinder.BlockFindService;
 import com.gtnh.findit.service.blockfinder.ClientBlockFindService;
 import com.gtnh.findit.service.cooldown.SearchCooldownService;

--- a/src/main/java/com/gtnh/findit/handler/ThaumcraftProvider.java
+++ b/src/main/java/com/gtnh/findit/handler/ThaumcraftProvider.java
@@ -1,6 +1,7 @@
 package com.gtnh.findit.handler;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 
@@ -18,22 +19,24 @@ public class ThaumcraftProvider implements IStackFilterProvider {
 
     static class AspectStackFilter implements IStackFilter {
 
-        AspectList aspects;
+        AspectList filterAspects;
 
-        AspectStackFilter(AspectList aspects) {
-            this.aspects = aspects;
+        AspectStackFilter(AspectList filterAspects) {
+            this.filterAspects = filterAspects;
         }
 
         @Override
         public boolean matches(FindItemRequest request) {
             ItemStack stack = request.getStackToFind();
-            if (!(stack.getItem() instanceof ItemAspect)) return false;
+            Item item = stack.getItem();
+            if (!(item instanceof ItemAspect || item instanceof IEssentiaContainerItem)) return false;
 
-            // An ItemAspect from ThaumcraftNeiPlugin never has multiple aspects.
-            Aspect stackAspect = ItemAspect.getAspects(stack).getAspects()[0];
-            if (stackAspect == null) return false;
+            AspectList stackAspects = ItemAspect.getAspects(stack);
+            if (stackAspects.size() != 1) return false;
 
-            return aspects.getAmount(stackAspect) > 0;
+            Aspect stackAspect = stackAspects.getAspects()[0];
+
+            return filterAspects.getAmount(stackAspect) > 0;
         }
     }
 

--- a/src/main/java/com/gtnh/findit/handler/ThaumcraftProvider.java
+++ b/src/main/java/com/gtnh/findit/handler/ThaumcraftProvider.java
@@ -1,0 +1,51 @@
+package com.gtnh.findit.handler;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import com.djgiannuzz.thaumcraftneiplugin.items.ItemAspect;
+import com.gtnh.findit.IStackFilter;
+import com.gtnh.findit.IStackFilter.IStackFilterProvider;
+import com.gtnh.findit.service.itemfinder.FindItemRequest;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.aspects.IAspectContainer;
+import thaumcraft.api.aspects.IEssentiaContainerItem;
+
+public class ThaumcraftProvider implements IStackFilterProvider {
+
+    static class AspectStackFilter implements IStackFilter {
+
+        AspectList aspects;
+
+        AspectStackFilter(AspectList aspects) {
+            this.aspects = aspects;
+        }
+
+        @Override
+        public boolean matches(FindItemRequest request) {
+            ItemStack stack = request.getStackToFind();
+            if (!(stack.getItem() instanceof ItemAspect)) return false;
+
+            // An ItemAspect from ThaumcraftNeiPlugin never has multiple aspects.
+            Aspect stackAspect = ItemAspect.getAspects(stack).getAspects()[0];
+            if (stackAspect == null) return false;
+
+            return aspects.getAmount(stackAspect) > 0;
+        }
+    }
+
+    @Override
+    public IStackFilter getFilter(EntityPlayer player, TileEntity tileEntity) {
+        if (!(tileEntity instanceof IAspectContainer aspectContainer)) return null;
+        return new AspectStackFilter(aspectContainer.getAspects());
+    }
+
+    @Override
+    public IStackFilter getFilter(EntityPlayer player, ItemStack stack) {
+        if (!(stack.getItem() instanceof IEssentiaContainerItem containerItem)) return null;
+        return new AspectStackFilter(containerItem.getAspects(stack));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17591

https://github.com/user-attachments/assets/6b4239ef-f8d4-40b9-a1a7-612c9322b5c1

Searching for an Aspect Item from Thaumcraft NEI Integration will find Items (Phials, Jars) and Blocks (Nodes, Jars, ...) that contain essentia of that aspect.

This currently only happens when doing the Find Item on the Aspect Item specifically. It could easily be added that this also happens when pressing it on a filled Phial or Jar directly, if that's desirable (would mirror the behavior for fluid ex. water bucket).