### PR TITLE
feat: add covers to T search

### DIFF
--- a/src/main/java/com/gtnh/findit/FindIt.java
+++ b/src/main/java/com/gtnh/findit/FindIt.java
@@ -10,6 +10,7 @@ import com.gtnh.findit.handler.AdventureBackpackProvider;
 import com.gtnh.findit.handler.BackpackProvider;
 import com.gtnh.findit.handler.DraconicEvolutionProvider;
 import com.gtnh.findit.handler.ForestryStackFilterProvider;
+import com.gtnh.findit.handler.GregTechCoverProvider;
 import com.gtnh.findit.handler.MinecraftProvider;
 import com.gtnh.findit.handler.ProjectRedExplorationProvider;
 import com.gtnh.findit.handler.ThaumcraftProvider;
@@ -93,6 +94,10 @@ public class FindIt {
 
         if (Loader.isModLoaded("Thaumcraft")) {
             this.pluginsList.add(new ThaumcraftProvider());
+        }
+
+        if (this.isGregTechLoaded) {
+            this.pluginsList.add(new GregTechCoverProvider());
         }
 
         this.pluginsList.add(new MinecraftProvider());

--- a/src/main/java/com/gtnh/findit/handler/GregTechCoverProvider.java
+++ b/src/main/java/com/gtnh/findit/handler/GregTechCoverProvider.java
@@ -1,0 +1,48 @@
+package com.gtnh.findit.handler;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.gtnh.findit.IStackFilter;
+import com.gtnh.findit.IStackFilter.IStackFilterProvider;
+
+import gregtech.api.covers.CoverRegistry;
+import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.api.util.GTUtility;
+
+public class GregTechCoverProvider implements IStackFilterProvider {
+
+    @Override
+    public IStackFilter getFilter(EntityPlayer player, TileEntity tileEntity) {
+        if (!(tileEntity instanceof ICoverable coverable)) {
+            return null;
+        }
+
+        return request -> {
+            ItemStack stackToFind = request.getStackToFind();
+            if (stackToFind == null || !CoverRegistry.isCover(stackToFind)) {
+                return false;
+            }
+
+            for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+                if (!coverable.hasCoverAtSide(side)) {
+                    continue;
+                }
+
+                ItemStack coverStack = coverable.getCoverItemAtSide(side);
+                if (GTUtility.areStacksEqual(stackToFind, coverStack, true)) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+    }
+
+    @Override
+    public IStackFilter getFilter(EntityPlayer player, ItemStack stack) {
+        return null;
+    }
+}


### PR DESCRIPTION
Y/T search is great for finding machines/items out in the world. This MR adds the ability to T search for covers. This is quite convenient for things like solar covers, tesla covers, etc. 

I filed an issue for the feature request over here: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25320

I had originally intended to be able to Y search, but the control flow for Y search requires a block, and cover's block is air, so making it a T search instead was a technical compromise.