### PR TITLE
feat: add ability to T search for contents of inventory covers

### DIFF
--- a/src/main/java/com/gtnh/findit/FindIt.java
+++ b/src/main/java/com/gtnh/findit/FindIt.java
@@ -10,6 +10,7 @@ import com.gtnh.findit.handler.AdventureBackpackProvider;
 import com.gtnh.findit.handler.BackpackProvider;
 import com.gtnh.findit.handler.DraconicEvolutionProvider;
 import com.gtnh.findit.handler.ForestryStackFilterProvider;
+import com.gtnh.findit.handler.GregTechCoverChestProvider;
 import com.gtnh.findit.handler.MinecraftProvider;
 import com.gtnh.findit.handler.ProjectRedExplorationProvider;
 import com.gtnh.findit.handler.ThaumcraftProvider;
@@ -93,6 +94,10 @@ public class FindIt {
 
         if (Loader.isModLoaded("Thaumcraft")) {
             this.pluginsList.add(new ThaumcraftProvider());
+        }
+
+        if (this.isGregTechLoaded) {
+            this.pluginsList.add(new GregTechCoverChestProvider());
         }
 
         this.pluginsList.add(new MinecraftProvider());

--- a/src/main/java/com/gtnh/findit/handler/GregTechCoverChestProvider.java
+++ b/src/main/java/com/gtnh/findit/handler/GregTechCoverChestProvider.java
@@ -1,0 +1,60 @@
+package com.gtnh.findit.handler;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.gtnewhorizons.modularui.api.forge.IItemHandler;
+import com.gtnh.findit.IStackFilter;
+import com.gtnh.findit.IStackFilter.IStackFilterProvider;
+import com.gtnh.findit.service.itemfinder.FindItemRequest;
+
+import gregtech.api.interfaces.tileentity.ICoverable;
+import gregtech.common.covers.Cover;
+import gregtech.common.covers.CoverChest;
+
+public class GregTechCoverChestProvider implements IStackFilterProvider {
+
+    @Override
+    public IStackFilter getFilter(EntityPlayer player, TileEntity tileEntity) {
+        if (!(tileEntity instanceof ICoverable coverable)) {
+            return null;
+        }
+
+        return request -> {
+            for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+                if (!coverable.hasCoverAtSide(side)) {
+                    continue;
+                }
+
+                if (coverChestMatches(player, request, coverable.getCoverAtSide(side))) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+    }
+
+    @Override
+    public IStackFilter getFilter(EntityPlayer player, ItemStack stack) {
+        return null;
+    }
+
+    private static boolean coverChestMatches(EntityPlayer player, FindItemRequest request, Cover cover) {
+        if (!(cover instanceof CoverChest coverChest)) {
+            return false;
+        }
+
+        IItemHandler items = coverChest.getItems();
+        for (int slot = 0; slot < items.getSlots(); slot++) {
+            ItemStack slotItem = items.getStackInSlot(slot);
+            if (slotItem != null && request.isStackSatisfies(player, slotItem)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
This MR not to be confused with #31 allows for T searching to search the contents of CoverChests AKA the Item Holder covers. This resolves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18282